### PR TITLE
GP-522: markdownlinting works on iOS project as long as we skip the /…

### DIFF
--- a/runlint.sh
+++ b/runlint.sh
@@ -6,7 +6,7 @@ wd=`pwd`
 
 cd /home/node
 
-npm run lint -- -i $wd/node_modules $wd/*.md
-npm run lint -- -i $wd/node_modules $wd/**/*.md
+npm run lint -- -i $wd/node_modules -i $wd/Pods $wd/*.md
+npm run lint -- -i $wd/node_modules -i $wd/Pods $wd/**/*.md
 
 

--- a/test
+++ b/test
@@ -1,1 +1,0 @@
-test text file

--- a/test
+++ b/test
@@ -1,0 +1,1 @@
+test text file


### PR DESCRIPTION
restrict markdown lint to just our source files by skipping the /Pods folder.